### PR TITLE
Fixes openpilot rm not really removing the folder

### DIFF
--- a/cmd/installer/setup.go
+++ b/cmd/installer/setup.go
@@ -9,34 +9,27 @@ import (
 func runSetup(client *ssh.Client, githubOwner, githubBranch string) error {
 	fmt.Println("Starting setup on the device...")
 
-	// 1. Change to /data directory
-	fmt.Println("Changing to /data directory...")
-	if _, err := executeCommand(client, "cd /data", false); err != nil {
-		// This command will likely return an empty output on success, so we ignore it.
-		// A failure would be caught by the error.
-	}
-
-	// 2. Remove existing openpilot directory
+	// 1. Remove existing openpilot directory
 	fmt.Println("Removing existing openpilot directory...")
-	if _, err := executeCommand(client, "rm -rf openpilot", false); err != nil {
+	if _, err := executeCommand(client, "rm -rf /data/openpilot", false); err != nil {
 		return fmt.Errorf("failed to remove openpilot directory: %v", err)
 	}
 
-	// 3. Clone openpilot repository
+	// 2. Clone openpilot repository
 	fmt.Println("Cloning openpilot repository...")
 	cloneCmd := fmt.Sprintf("git clone https://github.com/%s/openpilot.git openpilot -b %s --recurse-submodules --depth 1", githubOwner, githubBranch)
 	if _, err := executeCommand(client, "cd /data && "+cloneCmd, true); err != nil {
 		return fmt.Errorf("failed to clone openpilot: %v", err)
 	}
 
-	// 4. Patch neos.json for alternate update server
+	// 3. Patch neos.json for alternate update server
 	fmt.Println("Patching neos.json for alternate update server...")
 	patchCmd := "sed -i 's|commadist.azureedge.net/neosupdate|op-archive.mindflakes.com/neos20|g' /data/openpilot/selfdrive/hardware/eon/neos.json"
 	if _, err := executeCommand(client, patchCmd, false); err != nil {
 		return fmt.Errorf("failed to patch neos.json: %v", err)
 	}
 
-	// 5. Create continue.sh script
+	// 4. Create continue.sh script
 	fmt.Println("Creating continue.sh script...")
 	continueScript := `#!/usr/bin/bash\n\ncd /data/openpilot\n./launch_openpilot.sh\n`
 	createScriptCmd := fmt.Sprintf(`echo $'%s' > /data/data/com.termux/files/continue.sh`, continueScript)
@@ -44,13 +37,13 @@ func runSetup(client *ssh.Client, githubOwner, githubBranch string) error {
 		return fmt.Errorf("failed to create continue.sh: %v", err)
 	}
 
-	// 6. Make continue.sh executable
+	// 5. Make continue.sh executable
 	fmt.Println("Making continue.sh executable...")
 	if _, err := executeCommand(client, "chmod +x /data/data/com.termux/files/continue.sh", false); err != nil {
 		return fmt.Errorf("failed to make continue.sh executable: %v", err)
 	}
 
-	// 7. Reboot the device
+	// 6. Reboot the device
 	fmt.Println("Setup complete. Rebooting device...")
 	if _, err := executeCommand(client, "reboot", false); err != nil {
 		// The reboot command might close the connection before a response is received.


### PR DESCRIPTION
I had my C2 reboot while cloning github, the second time I tried the script it failed to install because openpilot was a folder and not empty which tells me that the rm is not working.

I then changed these lines and tried again, this time it worked. Doing the rm with the full path works as expected while the cd and rm (separate commands) don't (or at least for me).